### PR TITLE
Create RKE2 cluster in Rancher and run `node_command` on all cluster VMs

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -1,5 +1,5 @@
 module "lb" {
-  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-cloudscale?ref=vshn-lbaas-cloudscale-0.1.0"
+  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-cloudscale?ref=v1.0.0"
 
   node_name_suffix       = local.node_name_suffix
   cluster_id             = var.cluster_id

--- a/lb.tf
+++ b/lb.tf
@@ -3,6 +3,8 @@ module "lb" {
 
   node_name_suffix       = local.node_name_suffix
   cluster_id             = var.cluster_id
+  distribution           = "rke"
+  ingress_controller     = var.cluster_ingress_controller
   region                 = var.region
   ssh_keys               = var.ssh_keys
   privnet_id             = cloudscale_network.privnet.id

--- a/lb.tf
+++ b/lb.tf
@@ -12,5 +12,4 @@ module "lb" {
   router_backends          = module.worker.ip_addresses[*]
   lb_cloudscale_api_secret = var.lb_cloudscale_api_secret
   hieradata_repo_user      = var.hieradata_repo_user
-  internal_vip             = cidrhost(var.privnet_cidr, 100)
 }

--- a/lb.tf
+++ b/lb.tf
@@ -9,6 +9,7 @@ module "lb" {
   lb_count               = var.lb_count
   control_vshn_net_token = var.control_vshn_net_token
 
+  api_backends             = module.master.ip_addresses[*]
   router_backends          = module.worker.ip_addresses[*]
   lb_cloudscale_api_secret = var.lb_cloudscale_api_secret
   hieradata_repo_user      = var.hieradata_repo_user

--- a/master.tf
+++ b/master.tf
@@ -10,4 +10,10 @@ module "master" {
   flavor_slug      = "plus-16"
   subnet_uuid      = cloudscale_subnet.privnet_subnet.id
   ssh_keys         = var.node_ssh_keys
+
+  additional_user_data = {
+    "runcmd" = [
+      "${local.rke2_base_command} --etcd --controlplane",
+    ]
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,6 @@ output "dns_entries" {
     "node_name_suffix" = local.node_name_suffix,
     "api_vip"          = var.lb_count != 0 ? split("/", module.lb.api_vip[0].network)[0] : ""
     "router_vip"       = var.lb_count != 0 ? split("/", module.lb.router_vip[0].network)[0] : ""
-    "internal_vip"     = cidrhost(var.privnet_cidr, 100),
     "masters"          = module.master.ip_addresses,
     "cluster_id"       = var.cluster_id,
     "lbs"              = module.lb.public_ipv4_addresses,

--- a/provider.tf
+++ b/provider.tf
@@ -26,5 +26,9 @@ terraform {
       source  = "igal-s/gitfile"
       version = "1.0.0"
     }
+    rancher2 = {
+      source  = "rancher/rancher2"
+      version = "1.20.1"
+    }
   }
 }

--- a/rancher.tf
+++ b/rancher.tf
@@ -21,6 +21,11 @@ resource "rancher2_cluster_v2" "cluster" {
         local.api_fqdn
       ],
     })
+    etcd {
+      disable_snapshots      = var.cluster_etcd_snapshots.disabled
+      snapshot_retention     = var.cluster_etcd_snapshots.retention_count
+      snapshot_schedule_cron = var.cluster_etcd_snapshots.schedule_cron
+    }
     machine_selector_config {
       config = {
         protect-kernel-defaults = false

--- a/rancher.tf
+++ b/rancher.tf
@@ -1,0 +1,22 @@
+resource "rancher2_cluster_v2" "cluster" {
+  name = var.cluster_id
+
+  kubernetes_version    = var.cluster_kubernetes_version
+  enable_network_policy = true
+
+  rke_config {
+    local_auth_endpoint {
+      enabled = true
+      fqdn    = "api.${var.cluster_id}.${var.base_domain}"
+    }
+    machine_global_config = join("\n", [
+      "cni: \"${var.cluster_cni_plugin}\""
+    ])
+  }
+
+  lifecycle {
+    ignore_changes = [
+      resource_version
+    ]
+  }
+}

--- a/rancher.tf
+++ b/rancher.tf
@@ -21,6 +21,11 @@ resource "rancher2_cluster_v2" "cluster" {
         local.api_fqdn
       ],
     })
+    machine_selector_config {
+      config = {
+        protect-kernel-defaults = false
+      }
+    }
   }
 
   lifecycle {

--- a/rancher.tf
+++ b/rancher.tf
@@ -1,5 +1,7 @@
 locals {
   rke2_base_command = rancher2_cluster_v2.cluster.cluster_registration_token[0].node_command
+
+  api_fqdn = "api.${var.cluster_id}.${var.base_domain}"
 }
 
 resource "rancher2_cluster_v2" "cluster" {
@@ -11,11 +13,14 @@ resource "rancher2_cluster_v2" "cluster" {
   rke_config {
     local_auth_endpoint {
       enabled = true
-      fqdn    = "api.${var.cluster_id}.${var.base_domain}"
+      fqdn    = local.api_fqdn
     }
-    machine_global_config = join("\n", [
-      "cni: \"${var.cluster_cni_plugin}\""
-    ])
+    machine_global_config = yamlencode({
+      cni = var.cluster_cni_plugin,
+      tls-san = [
+        local.api_fqdn
+      ],
+    })
   }
 
   lifecycle {

--- a/rancher.tf
+++ b/rancher.tf
@@ -1,3 +1,7 @@
+locals {
+  rke2_base_command = rancher2_cluster_v2.cluster.cluster_registration_token[0].node_command
+}
+
 resource "rancher2_cluster_v2" "cluster" {
   name = var.cluster_id
 

--- a/templates/dns.zone
+++ b/templates/dns.zone
@@ -4,7 +4,6 @@
 $ORIGIN ${node_name_suffix}.
 
 api       IN A     ${api_vip}
-api-int   IN A     ${internal_vip}
 *.apps    IN A     ${router_vip}
 
 %{ for i, addr in lbs ~}

--- a/variables.tf
+++ b/variables.tf
@@ -15,6 +15,12 @@ variable "cluster_cni_plugin" {
   default     = "calico"
 }
 
+variable "cluster_ingress_controller" {
+  type        = string
+  description = "ingress controller running on the cluster"
+  default     = ""
+}
+
 variable "base_domain" {
   type        = string
   description = "Base domain of the cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,18 @@ variable "cluster_id" {
   description = "ID of the cluster"
 }
 
+variable "cluster_kubernetes_version" {
+  type        = string
+  description = "RKE2 K8s version for the cluster"
+  default     = "v1.21.4-rke2r2"
+}
+
+variable "cluster_cni_plugin" {
+  type        = string
+  description = "CNI plugin to use for the cluster"
+  default     = "calico"
+}
+
 variable "base_domain" {
   type        = string
   description = "Base domain of the cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,16 @@ variable "cluster_ingress_controller" {
   default     = ""
 }
 
+variable "cluster_etcd_snapshots" {
+  type        = object({ disabled = bool, retention_count = number, schedule_cron = string })
+  description = "RKE2 etcd snapshot configuration"
+  default = {
+    disabled        = false
+    retention_count = 5
+    schedule_cron   = "0 */4 * * *"
+  }
+}
+
 variable "base_domain" {
   type        = string
   description = "Base domain of the cluster"

--- a/variables.tf
+++ b/variables.tf
@@ -29,12 +29,23 @@ variable "ssh_keys" {
   type        = list(string)
   description = "SSH keys to add to LBs"
   default     = []
+
+  validation {
+    condition     = length(var.ssh_keys) > 0
+    error_message = "You must specify at least one SSH key for the LBs."
+  }
 }
 
 variable "node_ssh_keys" {
   type        = list(string)
   description = "SSH keys to add to cluster nodes"
   default     = []
+
+  validation {
+    condition     = length(var.node_ssh_keys) > 0
+    error_message = "You must specify at least one SSH key for the cluster nodes."
+  }
+
 }
 
 variable "privnet_cidr" {

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_id" {
 variable "cluster_kubernetes_version" {
   type        = string
   description = "RKE2 K8s version for the cluster"
-  default     = "v1.21.4-rke2r2"
+  default     = "v1.21.4+rke2r2"
 }
 
 variable "cluster_cni_plugin" {

--- a/variables.tf
+++ b/variables.tf
@@ -42,11 +42,6 @@ variable "privnet_cidr" {
   description = "CIDR of the private net to use"
 }
 
-variable "bootstrap_count" {
-  type    = number
-  default = 0
-}
-
 variable "lb_count" {
   type    = number
   default = 2

--- a/worker.tf
+++ b/worker.tf
@@ -11,6 +11,12 @@ module "worker" {
   volume_size_gb   = var.worker_volume_size_gb
   subnet_uuid      = cloudscale_subnet.privnet_subnet.id
   ssh_keys         = var.node_ssh_keys
+
+  additional_user_data = {
+    "runcmd" = [
+      "${local.rke2_base_command} --worker",
+    ]
+  }
 }
 
 // Additional worker groups.
@@ -30,4 +36,10 @@ module "additional_worker" {
   volume_size_gb   = each.value.volume_size_gb != null ? each.value.volume_size_gb : var.worker_volume_size_gb
   subnet_uuid      = cloudscale_subnet.privnet_subnet.id
   ssh_keys         = var.node_ssh_keys
+
+  additional_user_data = {
+    "runcmd" = [
+      "${local.rke2_base_command} --worker",
+    ]
+  }
 }


### PR DESCRIPTION
* Add `rancher2` provider
* Create `rancher2_cluster_v2` resource to create an RKE2 cluster via Rancher
* Run the resulting `node_command` on all master and worker VMs with appropriate role flags (`--etcd --controlplane` for master VMs, `--worker` for worker VMs)

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update LB module to new version once all changes in https://github.com/appuio/terraform-modules/tree/wip are merged

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
