### PR TITLE
Set prevent_destroy to true for nodes

### DIFF
--- a/modules/node-group/main.tf
+++ b/modules/node-group/main.tf
@@ -56,5 +56,6 @@ resource "cloudscale_server" "node" {
       skip_waiting_for_ssh_host_keys,
       image_slug,
     ]
+    prevent_destroy = true
   }
 }


### PR DESCRIPTION
This PR makes the Terraform lifecycle option "prevent_destroy" configurable and sets it to `true` by default.
This is done so that you have to consciously disable it for certain node groups.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
