### PR TITLE
Bump Terraform to v1.3.x and module lbaas-cloudscale to v3.0.0

### DIFF
--- a/lb.tf
+++ b/lb.tf
@@ -1,5 +1,5 @@
 module "lb" {
-  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-cloudscale?ref=v2.7.0"
+  source = "git::https://github.com/appuio/terraform-modules.git//modules/vshn-lbaas-cloudscale?ref=v3.0.0"
 
   node_name_suffix       = local.node_name_suffix
   cluster_id             = var.cluster_id

--- a/modules/node-group/providers.tf
+++ b/modules/node-group/providers.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.3.0"
   required_providers {
     cloudscale = {
       source = "cloudscale-ch/cloudscale"

--- a/provider.tf
+++ b/provider.tf
@@ -1,14 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
-  // Use experimental feature to allow making object fields optional, cf.
-  // https://www.terraform.io/docs/language/expressions/type-constraints.html#experimental-optional-object-type-attributes
-  //
-  // While there's no guarantee this feature doesn't see breaking changes even
-  // in minor releases, I think the upsides to allow users to omit some
-  // configurations for additional worker groups (e.g. node state, disk size)
-  // outweigh potential changes that we need to make in the future.
-  // -SG, 2021-08-02
-  experiments = [module_variable_optional_attrs]
+  required_version = ">= 1.3.0"
   required_providers {
     cloudscale = {
       source  = "cloudscale-ch/cloudscale"


### PR DESCRIPTION
This PR makes the module ready for Terraform 1.3.0 and therefore introduces a breaking change, since v1.3.0 is now the minimum required version.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
